### PR TITLE
Fix `calculateDimensions` for anamorphic streams

### DIFF
--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -402,6 +402,15 @@ void MovieDecoder::convertAndScaleFrame(PixelFormat format, int scaledSize, bool
 
 void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio, int& destWidth, int& destHeight)
 {
+    AVRational par = av_guess_sample_aspect_ratio(m_pFormatContext, m_pVideoStream, m_pFrame);
+    bool anamorphic = false;
+
+    // if the pixel aspect ratio is defined and is not 1, we have an anamorphic stream
+    if (par.num != 0 && (float) par.num / par.den != 1.0)
+    {
+        anamorphic = true;
+    }
+
     if (squareSize == 0)
     {
         // use original video size
@@ -417,12 +426,10 @@ void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio,
     {
         int srcWidth            = m_pVideoCodecContext->width;
         int srcHeight           = m_pVideoCodecContext->height;
-        int ascpectNominator    = m_pVideoCodecContext->sample_aspect_ratio.num;
-        int ascpectDenominator  = m_pVideoCodecContext->sample_aspect_ratio.den;
 
-        if (ascpectNominator != 0 && ascpectDenominator != 0)
+        if (anamorphic)
         {
-            srcWidth = srcWidth * ascpectNominator / ascpectDenominator;
+            srcWidth = srcWidth * par.num / par.den;
         }
 
         if (srcWidth > srcHeight)

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -406,7 +406,7 @@ void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio,
     bool anamorphic = false;
 
     // if the pixel aspect ratio is defined and is not 1, we have an anamorphic stream
-    if (par.num != 0 && (float) par.num / par.den != 1.0)
+    if (par.num != 0 && static_cast<float>(par.num) / par.den != 1.0)
     {
         anamorphic = true;
     }

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -405,7 +405,7 @@ void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio,
     AVRational par = av_guess_sample_aspect_ratio(m_pFormatContext, m_pVideoStream, m_pFrame);
 
     // if the pixel aspect ratio is defined and is not 1, we have an anamorphic stream
-    bool anamorphic = par.num != 0 && static_cast<float>(par.num) / par.den != 1.0f;
+    bool anamorphic = par.num != 0 && par.num != par.den;
 
     if (squareSize == 0)
     {

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -403,13 +403,9 @@ void MovieDecoder::convertAndScaleFrame(PixelFormat format, int scaledSize, bool
 void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio, int& destWidth, int& destHeight)
 {
     AVRational par = av_guess_sample_aspect_ratio(m_pFormatContext, m_pVideoStream, m_pFrame);
-    bool anamorphic = false;
 
     // if the pixel aspect ratio is defined and is not 1, we have an anamorphic stream
-    if (par.num != 0 && static_cast<float>(par.num) / par.den != 1.0)
-    {
-        anamorphic = true;
-    }
+    bool anamorphic = par.num != 0 && static_cast<float>(par.num) / par.den != 1.0;
 
     if (squareSize == 0)
     {

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -405,7 +405,7 @@ void MovieDecoder::calculateDimensions(int squareSize, bool maintainAspectRatio,
     AVRational par = av_guess_sample_aspect_ratio(m_pFormatContext, m_pVideoStream, m_pFrame);
 
     // if the pixel aspect ratio is defined and is not 1, we have an anamorphic stream
-    bool anamorphic = par.num != 0 && static_cast<float>(par.num) / par.den != 1.0;
+    bool anamorphic = par.num != 0 && static_cast<float>(par.num) / par.den != 1.0f;
 
     if (squareSize == 0)
     {


### PR DESCRIPTION
Fixes Issue #85 

You were using the sample_aspect_ratio from the AVCodecContext struct, which is not always accurate and may not always contain the sample aspect ratio, so I switched it to use the util function `av_guess_sample_aspect_ratio`, which is much more reliable. This also meant changing the anamorphic condition. If the determined Pixel Aspect Ratio (what ffmpeg calls the Sample Aspect Ratio) is undefined or 1, the stream is not anamorphic. If it is not, then the stream does not contain square pixels and is therefore anamorphic.

All enabled tests in `ffmpegthumbnailertest` still pass.

Let me know if you need anything else from this or have any clarifying questions. Thanks!