### PR TITLE
Fallback when smart frame detection fails

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -127,7 +127,7 @@ void VideoThumbnailer::generateThumbnail(const string& videoFile, ImageWriter& i
         }
         catch (const exception& e)
         {
-            TraceMessage(ThumbnailerLogLevelInfo, std::string(e.what()) + ", will use first frame");
+            std::cerr <<  std::string(e.what()) + ", will use first frame";
 
             //seeking failed, try the first frame again
             movieDecoder.destroy();
@@ -140,7 +140,16 @@ void VideoThumbnailer::generateThumbnail(const string& videoFile, ImageWriter& i
 
     if (m_SmartFrameSelection)
     {
-        generateSmartThumbnail(movieDecoder, videoFrame);
+        try
+        {
+            generateSmartThumbnail(movieDecoder, videoFrame);
+        }
+        catch (const exception& e)
+        {
+            std::cerr <<  std::string(e.what()) + ". Smartframe selection failed. Retrying without smart frame detection.";
+            m_SmartFrameSelection = false;
+            generateThumbnail(videoFile, imageWriter, pAvContext);
+        }
     }
     else
     {

--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -146,7 +146,7 @@ void VideoThumbnailer::generateThumbnail(const string& videoFile, ImageWriter& i
         }
         catch (const exception& e)
         {
-            std::cerr <<  std::string(e.what()) + ". Smartframe selection failed. Retrying without smart frame detection.";
+            std::cerr <<  std::string(e.what()) + ". Smart frame selection failed. Retrying without smart frame detection.";
             m_SmartFrameSelection = false;
             generateThumbnail(videoFile, imageWriter, pAvContext);
         }

--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -127,8 +127,8 @@ void VideoThumbnailer::generateThumbnail(const string& videoFile, ImageWriter& i
         }
         catch (const exception& e)
         {
-            std::cerr <<  std::string(e.what()) + ", will use first frame";
-
+            TraceMessage(ThumbnailerLogLevelError, std::string(e.what()) + ", will use first frame.");  
+            
             //seeking failed, try the first frame again
             movieDecoder.destroy();
             movieDecoder.initialize(videoFile);
@@ -146,7 +146,7 @@ void VideoThumbnailer::generateThumbnail(const string& videoFile, ImageWriter& i
         }
         catch (const exception& e)
         {
-            std::cerr <<  std::string(e.what()) + ". Smart frame selection failed. Retrying without smart frame detection.";
+            TraceMessage(ThumbnailerLogLevelError, std::string(e.what()) + ". Smart frame selection failed. Retrying without smart frame detection.");  
             m_SmartFrameSelection = false;
             generateThumbnail(videoFile, imageWriter, pAvContext);
         }


### PR DESCRIPTION
We're using ffmpegthumbnailer to thumbnail all videos uploaded through our application. We always use smart frame detection "-p" because clients will often complain if their thumbnails are not accurate. However, if smart frame detection fails, we'd much rather have a regular old thumbnail if there's a problem reading the file (as opposed to no thumbnail). There's a function in ffmpeg, 'av_read_frame', that was causing a "decodeFrame()" fail in ffmpegthumbnailer on some files (which is only called when smart frame detection is on). So, I implemented both a try catch to turn off smart frame detection should it fail while attempting to generate thumbnails, and a retry generateThumbnail after turning of smart frame detection.

Secondly, we pipe the resulting image from ffmpegthumbnailer directly to Imagemagick's identify. 'TraceMessage' outputs to stdout, which means if an error occurs and 'TraceMessage(ThumbnailLogLevelInfo, ...)' is called, the image produced from ffmpegthumbnailer also has the stdout message in it. This obviously trips up Identify because the image is no longer a valid jpeg, png, etc...

Wheeew, I know that was a lot!

