### PR TITLE
Fix libffmpegthumbnailer.pc to work with multilib systems

### DIFF
--- a/libffmpegthumbnailer.pc.in
+++ b/libffmpegthumbnailer.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: libffmpegthumbnailer


### PR DESCRIPTION
With slackware, 64-bit systems install their libraries to `/lib64` and `/usr/lib64` while 32-bit systems use `/lib` and `/usr/lib`. So for multilib systems that have both at least some programs that depend on ffmpegthumbnailer will fail to build with linking errors where it tries to use 32-bit libraries instead of the correct 64-bit libraries. One example of this is the file manager spacefm.

So simply dehardcoding `libdir=${exec_prefix}/lib` resolves this.

Additionally I have only been able to reproduce this with pkgconf and not the legacy pkg-config, I suspect this is because pkg-config is more permissive towards buggy pkgconfig files.