### PR TITLE
Fix for "Value too large for defined data type"

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.h
+++ b/libffmpegthumbnailer/videothumbnailer.h
@@ -17,6 +17,8 @@
 #ifndef VIDEO_THUMBNAILER_H
 #define VIDEO_THUMBNAILER_H
 
+#define _FILE_OFFSET_BITS 64
+
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
This fix the error message "Value too large for defined data type" when ffmpegthumbnailer is compiled on armhf