### PR TITLE
kffmpegthumbnailer: Remove deprecated thumbnail frame flag (fixes #184)

### DIFF
--- a/kffmpegthumbnailer/kffmpegthumbnailer.cpp
+++ b/kffmpegthumbnailer/kffmpegthumbnailer.cpp
@@ -60,6 +60,6 @@ bool KFFMpegThumbnailer::create(const QString& path, int width, int /*heigth*/, 
 
 ThumbCreator::Flags KFFMpegThumbnailer::flags() const
 {
-    return (Flags)(DrawFrame);
+    return (Flags)(None);
 }
 


### PR DESCRIPTION
DrawFrame is [deprecated since 5.32](https://api.kde.org/frameworks/kio/html/classThumbCreator.html#adcc1899c71c88a0278604af8fc728245) and looks ugly