### PR TITLE
Added support for generating thumb sequences (ThumbSequenceCreator)

### DIFF
--- a/kffmpegthumbnailer/kffmpegthumbnailer.cpp
+++ b/kffmpegthumbnailer/kffmpegthumbnailer.cpp
@@ -45,7 +45,7 @@ KFFMpegThumbnailer::~KFFMpegThumbnailer()
 
 bool KFFMpegThumbnailer::create(const QString& path, int width, int /*height*/, QImage& img)
 {
-    int seqIdx = (int) sequenceIndex();
+    int seqIdx = static_cast<int>(sequenceIndex());
 
     const QList<int> seekPercentages = KFFMpegThumbnailerSettings::sequenceSeekPercentages();
     const int numSeekPercentages = seekPercentages.size();
@@ -92,7 +92,7 @@ bool KFFMpegThumbnailer::create(const QString& path, int width, int /*height*/, 
         return false;
     }
 
-    const int cacheCost = (int) ((img.sizeInBytes()+1023) / 1024);
+    const int cacheCost = static_cast<int>((img.sizeInBytes()+1023) / 1024);
     thumbCache.insert(cacheKey, new QImage(img), cacheCost);
 
     return true;
@@ -100,12 +100,12 @@ bool KFFMpegThumbnailer::create(const QString& path, int width, int /*height*/, 
 
 float KFFMpegThumbnailer::sequenceIndexWraparoundPoint() const
 {
-    return (float) KFFMpegThumbnailerSettings::sequenceSeekPercentages().size();
+    return static_cast<float>(KFFMpegThumbnailerSettings::sequenceSeekPercentages().size());
 }
 
 ThumbCreator::Flags KFFMpegThumbnailer::flags() const
 {
-    return (Flags)(None);
+    return static_cast<Flags>(None);
 }
 
 QWidget *KFFMpegThumbnailer::createConfigurationWidget()

--- a/kffmpegthumbnailer/kffmpegthumbnailer.desktop
+++ b/kffmpegthumbnailer/kffmpegthumbnailer.desktop
@@ -7,6 +7,7 @@ MimeType=video/*;application/x-flash-video;application/vnd.ms-asf;application/vn
 X-KDE-Library=kffmpegthumbnailer
 ServiceTypes=ThumbCreator
 CacheThumbnail=true
+HandleSequences=true
 ThumbnailerVersion=2
 IgnoreMaximumSize=true
 Configurable=true

--- a/kffmpegthumbnailer/kffmpegthumbnailer.h
+++ b/kffmpegthumbnailer/kffmpegthumbnailer.h
@@ -18,19 +18,27 @@
 #define KFFMPEG_THUMBNAILER_H
 
 #include <QObject>
+#include <QCache>
 #include <QCheckBox>
-#include <kio/thumbcreator.h>
+#include <QLineEdit>
+#include <QSpinBox>
+#include <kio/thumbsequencecreator.h>
 
 #include <libffmpegthumbnailer/videothumbnailer.h>
 #include <libffmpegthumbnailer/filmstripfilter.h>
 
-class KFFMpegThumbnailer : public QObject, public ThumbCreator
+class KFFMpegThumbnailer : public QObject, public ThumbSequenceCreator
 {
     Q_OBJECT
+
+private:
+    typedef QCache<QString, QImage> ThumbCache;
+
 public:
     KFFMpegThumbnailer();
     virtual ~KFFMpegThumbnailer();
     virtual bool create(const QString& path, int width, int height, QImage& img) override;
+    virtual float sequenceIndexWraparoundPoint() const;
     virtual Flags flags() const override;
     virtual QWidget* createConfigurationWidget() override;
     virtual void writeConfiguration(const QWidget* configurationWidget) override;
@@ -38,9 +46,12 @@ public:
 private:
     ffmpegthumbnailer::VideoThumbnailer    m_Thumbnailer;
     ffmpegthumbnailer::FilmStripFilter     m_FilmStrip;
+    ThumbCache thumbCache;
     QCheckBox*                             m_addFilmStripCheckBox;
     QCheckBox*                             m_useMetadataCheckBox;
     QCheckBox*                             m_useSmartSelectionCheckBox;
+    QLineEdit*                             m_sequenceSeekPercentagesLineEdit;
+    QSpinBox*                              m_thumbCacheSizeSpinBox;
 };
 
 #endif

--- a/kffmpegthumbnailer/kffmpegthumbnailersettings5.kcfg
+++ b/kffmpegthumbnailer/kffmpegthumbnailersettings5.kcfg
@@ -17,5 +17,13 @@
           <label>Use smart (slower) frame selection</label>
           <default>false</default>
       </entry>
+      <entry name="sequenceSeekPercentages" type="IntList">
+          <label>Sequence seek percentages</label>
+          <default>20,35,50,65,80</default>
+      </entry>
+      <entry name="cacheSize" type="UInt">
+          <label>Cache size (KiB)</label>
+          <default>51200</default>
+      </entry>
     </group>
 </kcfg>


### PR DESCRIPTION
This adds support for the [ThumbSequenceCreator](https://invent.kde.org/frameworks/kio/-/blob/master/src/widgets/thumbsequencecreator.h) interface to kffmpegthumbnailer, which allows generation of a sequence of thumbs instead of just one. This is useful e.g. for hover previews, where the user sees a slideshow of video frames when they hover over a video file icon.

Also adds some primitive runtime caching to speed this up because due to limitations of ThumbSequenceCreator, there is currently no way for the frontend to know when the sequence starts looping, so it just keeps requesting "new" frames from the plugin indefinitely.

You can [take a look here](https://invent.kde.org/system/dolphin/-/merge_requests/167) to see what I have done with it in Dolphin, the KDE file manager. There's also a video of it in action over there.