### PR TITLE
Port to FFmpeg4

### DIFF
--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -41,11 +41,6 @@ using namespace std;
 namespace ffmpegthumbnailer
 {
 
-struct SilenceLogLevel
-{
-    SilenceLogLevel() { av_log_set_level(AV_LOG_QUIET); }
-};
-
 MovieDecoder::MovieDecoder(AVFormatContext* pavContext)
 : m_VideoStream(-1)
 , m_pFormatContext(pavContext)

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -379,11 +379,6 @@ std::string MovieDecoder::createScaleString(const std::string& sizeString, bool 
 
 void MovieDecoder::initializeFilterGraph(const AVRational& timeBase, const std::string& size, bool maintainAspectRatio)
 {
-    static const AVPixelFormat pixelFormats[] = { AV_PIX_FMT_RGB24, AV_PIX_FMT_NONE };
-
-    auto del = [] (AVBufferSinkParams* p) { av_freep(p); };
-    std::unique_ptr<AVBufferSinkParams, decltype(del)> buffersinkParams(av_buffersink_params_alloc(), del);
-
     m_pFilterGraph = avfilter_graph_alloc();
     assert(m_pFilterGraph);
 
@@ -395,10 +390,8 @@ void MovieDecoder::initializeFilterGraph(const AVRational& timeBase, const std::
 
     checkRc(avfilter_graph_create_filter(&m_pFilterSource, avfilter_get_by_name("buffer"), "thumb_buffer", ss.str().c_str(), nullptr, m_pFilterGraph),
             "Failed to create filter source");
-    buffersinkParams->pixel_fmts = pixelFormats;
-    checkRc(avfilter_graph_create_filter(&m_pFilterSink, avfilter_get_by_name("buffersink"), "thumb_buffersink", nullptr, buffersinkParams.get(), m_pFilterGraph),
+    checkRc(avfilter_graph_create_filter(&m_pFilterSink, avfilter_get_by_name("buffersink"), "thumb_buffersink", nullptr, nullptr, m_pFilterGraph),
             "Failed to create filter sink");
-    buffersinkParams.release();
 
     AVFilterContext* yadifFilter = nullptr;
     if (m_pFrame->interlaced_frame != 0)

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -145,10 +145,10 @@ int32_t MovieDecoder::findPreferedVideoStream(bool preferEmbeddedMetadata)
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; ++i)
     {
         AVStream *stream = m_pFormatContext->streams[i];
-        auto ctx = m_pFormatContext->streams[i]->codec;
-        if (ctx->codec_type == AVMEDIA_TYPE_VIDEO)
+        auto par = m_pFormatContext->streams[i]->codecpar;
+        if (par->codec_type == AVMEDIA_TYPE_VIDEO)
         {
-            if (!preferEmbeddedMetadata || !isStillImageCodec(ctx->codec_id))
+            if (!preferEmbeddedMetadata || !isStillImageCodec(par->codec_id))
             {
                 videoStreams.push_back(i);
                 continue;

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -65,8 +65,6 @@ MovieDecoder::~MovieDecoder()
 
 void MovieDecoder::initialize(const string& filename, bool preferEmbeddedMetadata)
 {
-    av_register_all();
-    avcodec_register_all();
     avformat_network_init();
 
     string inputFile = filename == "-" ? "pipe:" : filename;
@@ -385,8 +383,6 @@ void MovieDecoder::initializeFilterGraph(const AVRational& timeBase, const std::
 
     auto del = [] (AVBufferSinkParams* p) { av_freep(p); };
     std::unique_ptr<AVBufferSinkParams, decltype(del)> buffersinkParams(av_buffersink_params_alloc(), del);
-
-    avfilter_register_all();
 
     m_pFilterGraph = avfilter_graph_alloc();
     assert(m_pFilterGraph);

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -570,8 +570,6 @@ bool MovieDecoder::getVideoPacket()
     bool framesAvailable = true;
     bool frameDecoded = false;
 
-    int attempts = 0;
-
     if (m_pPacket)
     {
         av_packet_unref(m_pPacket);

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -484,7 +484,7 @@ void MovieDecoder::seek(int timeInSeconds)
     }
 
     checkRc(av_seek_frame(m_pFormatContext, -1, timestamp, 0), "Seeking in video failed");
-    avcodec_flush_buffers(m_pFormatContext->streams[m_VideoStream]->codec);
+    avcodec_flush_buffers(m_pVideoCodecContext);
 
     int keyFrameAttempts = 0;
     bool gotFrame;

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -503,12 +503,12 @@ void MovieDecoder::seek(int timeInSeconds)
     avcodec_flush_buffers(m_pFormatContext->streams[m_VideoStream]->codec);
 
     int keyFrameAttempts = 0;
-    bool gotFrame = 0;
+    bool gotFrame;
 
     do
     {
         int count = 0;
-        gotFrame = 0;
+        gotFrame = false;
 
         while (!gotFrame && count < 20)
         {


### PR DESCRIPTION
Removes use of deprecated functionality. Requires a minimum of FFmpeg 4.x. Tested against FFmpeg 4.3.1.