### PR TITLE
Fix a -fpermissive build issue.

### DIFF
--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -195,7 +195,7 @@ void MovieDecoder::initializeVideo(bool preferEmbeddedMetadata)
     }
 
     m_pVideoStream = m_pFormatContext->streams[m_VideoStream];
-    m_pVideoCodec = avcodec_find_decoder(m_pVideoStream->codecpar->codec_id);
+    m_pVideoCodec = const_cast<AVCodec*>(avcodec_find_decoder(m_pVideoStream->codecpar->codec_id));
 
     if (m_pVideoCodec == nullptr)
     {


### PR DESCRIPTION
On gentoo with a recent ffmpeg git the build fails. (https://github.com/FFmpeg/FFmpeg/commit/5541cffa17a8c45004e5ceeda52d4d6b2acee037)
```
samu: job failed: /usr/lib/ccache/bin/c++ -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -I. -fPIC -std=c++11 -MD -MT CMakeFiles/libffmpegthumbnailerobj.dir/libffmpegthumbnailer/moviedecoder.cpp.o -MF CMakeFiles/libffmpegthumbnailerobj.dir/libffmpegthumbnailer/moviedecoder.cpp.o.d -o CMakeFiles/libffmpegthumbnailerobj.dir/libffmpegthumbnailer/moviedecoder.cpp.o -c ../libffmpegthumbnailer/moviedecoder.cpp
../libffmpegthumbnailer/moviedecoder.cpp: In member function ‘void ffmpegthumbnailer::MovieDecoder::initializeVideo(bool)’:
../libffmpegthumbnailer/moviedecoder.cpp:198:41: error: invalid conversion from ‘const AVCodec*’ to ‘AVCodec*’ [-fpermissive]
  198 |     m_pVideoCodec = avcodec_find_decoder(m_pVideoStream->codecpar->codec_id);
      |                     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                         |
      |                                         const AVCodec*
samu: subcommand failed
```
I am not sure this is the best way of solving the issue so please confirm, thanks!