### PR TITLE
Constify AVCodec

### DIFF
--- a/libffmpegthumbnailer/moviedecoder.h
+++ b/libffmpegthumbnailer/moviedecoder.h
@@ -78,7 +78,7 @@ private:
     int                     m_VideoStream;
     AVFormatContext*        m_pFormatContext;
     AVCodecContext*         m_pVideoCodecContext;
-    AVCodec*                m_pVideoCodec;
+    const AVCodec*          m_pVideoCodec;
     AVFilterGraph*          m_pFilterGraph;
     AVFilterContext*        m_pFilterSource;
     AVFilterContext*        m_pFilterSink;


### PR DESCRIPTION
FFmpeg recently constify the AVCodec API. 
new avcodec_find_decoder function declaration is: `const AVCodec *avcodec_find_decoder(enum AVCodecID id)` 
Here is the original ffmpeg commit: https://github.com/FFmpeg/FFmpeg/commit/626535f6a169e2d821b969e0ea77125ba7482113

It fixes the same issue reported in #199 PR.