### PR TITLE
clang-tidy: add missing reserve

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -204,6 +204,7 @@ VideoFrameInfo VideoThumbnailer::generateThumbnail(const string& videoFile, Imag
     applyFilters(videoFrame);
 
     vector<uint8_t*> rowPointers;
+    rowPointers.reserve(videoFrame.height);
     for (int i = 0; i < videoFrame.height; ++i)
     {
         rowPointers.push_back(&(videoFrame.frameData[i * videoFrame.lineSize]));


### PR DESCRIPTION
Found with performance-inefficient-vector-operation

Signed-off-by: Rosen Penev <rosenp@gmail.com>