### PR TITLE
jpegwriter: default initialize variables

### DIFF
--- a/libffmpegthumbnailer/jpegwriter.cpp
+++ b/libffmpegthumbnailer/jpegwriter.cpp
@@ -40,9 +40,6 @@ static boolean jpegFlushWorkBuffer(j_compress_ptr pCompressionInfo);
 static void jpegDestroyDestination(j_compress_ptr pCompressionInfo);
 
 JpegWriter::JpegWriter(const string& outputFile)
-: ImageWriter()
-, m_pFile(nullptr)
-, m_pBufferWriter(nullptr)
 {
     init();
 	m_pFile = outputFile == "-" ? stdout : fopen(outputFile.c_str(), "wb");
@@ -56,9 +53,6 @@ JpegWriter::JpegWriter(const string& outputFile)
 }
 
 JpegWriter::JpegWriter(std::vector<uint8_t>& outputBuffer)
-: ImageWriter()
-, m_pFile(nullptr)
-, m_pBufferWriter(nullptr)
 {
     init();
 

--- a/libffmpegthumbnailer/jpegwriter.h
+++ b/libffmpegthumbnailer/jpegwriter.h
@@ -45,10 +45,10 @@ private:
     void init();
     
 private:
-    FILE*                   m_pFile;
+    FILE*                   m_pFile{};
     jpeg_compress_struct    m_Compression;
     jpeg_error_mgr          m_ErrorHandler;
-    BufferWriter*           m_pBufferWriter;
+    BufferWriter*           m_pBufferWriter{};
 };
 
 }


### PR DESCRIPTION
Don't bother setting in the constructor.

Signed-off-by: Rosen Penev <rosenp@gmail.com>