### PR TITLE
clang-tidy: add missing override

### DIFF
--- a/libffmpegthumbnailer/filmstripfilter.h
+++ b/libffmpegthumbnailer/filmstripfilter.h
@@ -25,7 +25,7 @@ namespace ffmpegthumbnailer
 class FilmStripFilter : public IFilter
 {
 public:
-    void process(VideoFrame& videoFrame);
+    void process(VideoFrame& videoFrame) override;
 };
 
 }

--- a/libffmpegthumbnailer/ifilter.h
+++ b/libffmpegthumbnailer/ifilter.h
@@ -25,7 +25,7 @@ namespace ffmpegthumbnailer
 class IFilter
 {
 public:
-	virtual ~IFilter() {}
+    virtual ~IFilter() = default;
     virtual void process(VideoFrame& frameData) = 0;
 };
 

--- a/libffmpegthumbnailer/jpegwriter.h
+++ b/libffmpegthumbnailer/jpegwriter.h
@@ -36,11 +36,11 @@ class JpegWriter : public ImageWriter
 public:
     JpegWriter(const std::string& outputFile);
     JpegWriter(std::vector<uint8_t>& outputBuffer);
-    ~JpegWriter();
-    
-    void setText(const std::string& key, const std::string& value);
-    void writeFrame(uint8_t** rgbData, int width, int height, int quality);
-    
+    ~JpegWriter() override;
+
+    void setText(const std::string& key, const std::string& value) override;
+    void writeFrame(uint8_t** rgbData, int width, int height, int quality) override;
+
 private:
     void init();
     

--- a/libffmpegthumbnailer/pngwriter.h
+++ b/libffmpegthumbnailer/pngwriter.h
@@ -31,10 +31,10 @@ class PngWriter : public ImageWriter
 public:
     PngWriter(const std::string& outputFile);
     PngWriter(std::vector<uint8_t>& outputBuffer);
-    ~PngWriter();
+    ~PngWriter() override;
 
-    void setText(const std::string& key, const std::string& value);
-    void writeFrame(uint8_t** rgbData, int width, int height, int quality);
+    void setText(const std::string& key, const std::string& value) override;
+    void writeFrame(uint8_t** rgbData, int width, int height, int quality) override;
 
 private:
     void init();

--- a/libffmpegthumbnailer/rgbwriter.h
+++ b/libffmpegthumbnailer/rgbwriter.h
@@ -31,7 +31,7 @@ class RgbWriter : public ImageWriter
 public:
     RgbWriter(const std::string& outputFile);
     RgbWriter(std::vector<uint8_t>& outputBuffer);
-    ~RgbWriter();
+    ~RgbWriter() override;
 
     void setText(const std::string& key, const std::string& value) override;
     void writeFrame(uint8_t** rgbData, int width, int height, int quality) override;


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>