### PR TITLE
videothumbnailer.cpp: add <cstring> include for strerror()

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -32,6 +32,7 @@
 #include <stdexcept>
 #include <cassert>
 #include <cerrno>
+#include <cstring>
 #include <memory>
 #include <regex>
 #include <algorithm>


### PR DESCRIPTION
Upcoming gcc-12 cleaned implicit headers includes further
and exposed missing include as this build failure:

    libffmpegthumbnailer/videothumbnailer.cpp: In member function 'void ffmpegthumbnailer::VideoThumbnailer::writeImage(...)':
    libffmpegthumbnailer/videothumbnailer.cpp:274:109: error: 'strerror' was not declared in this scope; did you mean 'stderr'?
      274 |             TraceMessage(ThumbnailerLogLevelError, std::string("Failed to stat file ") + videoFile + " (" + strerror(errno) + ")");