### PR TITLE
remove Unknown enum member

### DIFF
--- a/libffmpegthumbnailer/imagetypes.h
+++ b/libffmpegthumbnailer/imagetypes.h
@@ -22,7 +22,6 @@ typedef enum ThumbnailerImageTypeEnum
     Png,
     Jpeg,
     Rgb,
-    Unknown
 } ThumbnailerImageType;
 
 #endif


### PR DESCRIPTION
This unfortunately conflicts with winioctl.h, which also has an Unknown enum member.

Fixes compilation under MinGW.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

```
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/winioctl.h:715:3: error: redefinition of enumerator 'Unknown'
  Unknown,F5_1Pt2_512,F3_1Pt44_512,F3_2Pt88_512,F3_20Pt8_512,F3_720_512,F5_360_512,F5_320_512,F5_320_1024,F5_180_512,F5_160_512,
  ^
../subprojects/ffmpegthumbnailer-2.2.2/libffmpegthumbnailer/imagetypes.h:25:5: note: previous definition is here
    Unknown
```