### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,7 @@ FFmpegThumbnailer 2.1.2
 - Take rotation metadata into account when generating thumbnails
 
 FFmpegThumbnailer 2.1.1
-- Buildable agains latest ffmpeg (currently breaks deinterlacing)
+- Buildable against latest ffmpeg (currently breaks deinterlacing)
 - Fallback when smart frame detection fails (thanks to johnnydeez)
 - Add MPEG-TS (MTS) support (thanks to marcinn)
 
@@ -67,11 +67,11 @@ version 2.0.4
 version 2.0.3
 - Writing to stdout is now supported
 - Support for gnome-vfs uris added. New configure flag (--enable-gnome-vfs),
-this puts a runtime dependancy on libgnome-vfs-2.0
+this puts a runtime dependency on libgnome-vfs-2.0
 
 version 2.0.2
 - Fixed compilation error against latest ffmpeg
-- Size of the filmstrip overlay is dependant on thumbnail size
+- Size of the filmstrip overlay is dependent on thumbnail size
 
 version 2.0.1
 - Setting the thumbnail size to 0 will use the original video size (thanks to John Fremlin)

--- a/libffmpegthumbnailer/moviedecoder.cpp
+++ b/libffmpegthumbnailer/moviedecoder.cpp
@@ -136,7 +136,7 @@ static bool isStillImageCodec(AVCodecID codecId)
             || codecId == AV_CODEC_ID_PNG;
 }
 
-int32_t MovieDecoder::findPreferedVideoStream(bool preferEmbeddedMetadata)
+int32_t MovieDecoder::findPreferredVideoStream(bool preferEmbeddedMetadata)
 {
     std::vector<int32_t> videoStreams;
     std::vector<int32_t> embeddedDataStream;
@@ -186,7 +186,7 @@ int32_t MovieDecoder::findPreferedVideoStream(bool preferEmbeddedMetadata)
 
 void MovieDecoder::initializeVideo(bool preferEmbeddedMetadata)
 {
-    m_VideoStream = findPreferedVideoStream(preferEmbeddedMetadata);
+    m_VideoStream = findPreferredVideoStream(preferEmbeddedMetadata);
 
     if (m_VideoStream < 0)
     {

--- a/libffmpegthumbnailer/moviedecoder.h
+++ b/libffmpegthumbnailer/moviedecoder.h
@@ -62,7 +62,7 @@ public:
     bool embeddedMetaDataIsAvailable();
 
 private:
-    int32_t findPreferedVideoStream(bool preferEmbeddedMetadata);
+    int32_t findPreferredVideoStream(bool preferEmbeddedMetadata);
 
     void initializeVideo(bool preferEmbeddedMetadata);
     void initializeFilterGraph(const AVRational& timeBase, const std::string& size, bool maintainAspectRatio);

--- a/test/testframework/catch.hpp
+++ b/test/testframework/catch.hpp
@@ -4658,7 +4658,7 @@ namespace Catch {
             ss << seed;
             ss >> config.rngSeed;
             if( ss.fail() )
-                throw std::runtime_error( "Argment to --rng-seed should be the word 'time' or a number" );
+                throw std::runtime_error( "Argument to --rng-seed should be the word 'time' or a number" );
         }
     }
     inline void setVerbosity( ConfigData& config, int level ) {
@@ -7323,7 +7323,7 @@ namespace Catch {
                 Colour colourGuard( Colour::Red );
                 Catch::cerr()
                     << "Tag name [" << tag << "] not allowed.\n"
-                    << "Tag names starting with non alpha-numeric characters are reserved\n";
+                    << "Tag names starting with non alphanumeric characters are reserved\n";
             }
             {
                 Colour colourGuard( Colour::FileName );
@@ -10442,4 +10442,3 @@ int main (int argc, char * const argv[]) {
 using Catch::Detail::Approx;
 
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-


### PR DESCRIPTION
Found via `codespell` and `typos --hidden --format brief`