### PR TITLE
fix removeFilter

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -354,9 +354,12 @@ void VideoThumbnailer::addFilter(IFilter* pFilter)
 
 void VideoThumbnailer::removeFilter(IFilter* pFilter)
 {
-    std::remove_if(m_Filters.begin(), m_Filters.end(), [pFilter] (IFilter* fil) {
-        return fil == pFilter;
-    });
+#ifdef __cpp_lib_erase_if
+    std::erase(m_Filters, pFilter);
+#else
+    auto r = std::remove(m_Filters.begin(), m_Filters.end(), pFilter);
+    m_Filters.erase(r, m_Filters.end());
+#endif
 }
 
 void VideoThumbnailer::clearFilters()


### PR DESCRIPTION
This is using remove_if without actually erasing anything, making this no-op.

C++20 has std::erase, so use that when available.

Found with clang:

warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]